### PR TITLE
Print tracing_id together with a metric

### DIFF
--- a/expfmt/text_create.go
+++ b/expfmt/text_create.go
@@ -323,6 +323,13 @@ func writeSample(
 			return written, err
 		}
 	}
+	if metric.TraceId != nil {
+		n, err = w.WriteString(fmt.Sprintf(" # {trace_id=\"%s\"}", *(metric.TraceId)))
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
 	err = w.WriteByte('\n')
 	written++
 	if err != nil {


### PR DESCRIPTION
Sample:
requests_total 40 #
{trace_id="eea76a3b02ffef0:38acd360a4848c53:3eb15567c45d71cb:1"}